### PR TITLE
Downgrade broken gitlab version

### DIFF
--- a/.github/dependabot_docker_proxy/Dockerfile
+++ b/.github/dependabot_docker_proxy/Dockerfile
@@ -13,6 +13,6 @@ FROM minio/minio:RELEASE.2023-04-20T17-56-55Z
 
 FROM mdernovoi/mlflow:v1.4.0
 
-FROM gitlab/gitlab-ce:15.11.2ce.0
+FROM gitlab/gitlab-ce:15.11.2-ce.0
 
 FROM gitlab/gitlab-runner:ubuntu-v15.11.0

--- a/.github/dependabot_docker_proxy/Dockerfile
+++ b/.github/dependabot_docker_proxy/Dockerfile
@@ -13,6 +13,6 @@ FROM minio/minio:RELEASE.2023-04-20T17-56-55Z
 
 FROM mdernovoi/mlflow:v1.4.0
 
-FROM gitlab/gitlab-ce:15.11.3-ce.0
+FROM gitlab/gitlab-ce:15.11.2ce.0
 
 FROM gitlab/gitlab-runner:ubuntu-v15.11.0

--- a/infrastructure/ansible/role_service-host/templates/service-compose.yaml.j2
+++ b/infrastructure/ansible/role_service-host/templates/service-compose.yaml.j2
@@ -275,7 +275,7 @@ services:
       - all
 
   gitlab:
-    image: gitlab/gitlab-ce:15.11.3-ce.0
+    image: gitlab/gitlab-ce:15.11.2-ce.0
     deploy:
         replicas: 1
         restart_policy:


### PR DESCRIPTION
The migration to gitlab 15.11.3 is broken [issue](https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/7809)